### PR TITLE
feat: basic fastapi backend prototype

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Backend
+DATABASE_URL=sqlite:///./test.db
+SECRET_KEY=changeme
+# Frontend
+VITE_API_URL=http://localhost:8000/api/v1

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,10 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+backend/test.db

--- a/README.md
+++ b/README.md
@@ -1,73 +1,37 @@
-# Welcome to your Lovable project
+# Trimestral Insight Hub (prototype)
 
-## Project info
+Este repositório contém um protótipo simples de backend FastAPI e frontend React.
 
-**URL**: https://lovable.dev/projects/ab864f43-07cc-48ce-ba73-fc067a664ad0
+## Backend
 
-## How can I edit this code?
+### Execução com SQLite
 
-There are several ways of editing your application.
+```bash
+cd backend
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
 
-**Use Lovable**
+### Execução com Docker/Postgres
 
-Simply visit the [Lovable Project](https://lovable.dev/projects/ab864f43-07cc-48ce-ba73-fc067a664ad0) and start prompting.
+```bash
+docker-compose up --build
+```
 
-Changes made via Lovable will be committed automatically to this repo.
+### Testes
 
-**Use your preferred IDE**
+```bash
+cd backend
+pytest
+```
 
-If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in Lovable.
+## Frontend
 
-The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
-
-Follow these steps:
-
-```sh
-# Step 1: Clone the repository using the project's Git URL.
-git clone <YOUR_GIT_URL>
-
-# Step 2: Navigate to the project directory.
-cd <YOUR_PROJECT_NAME>
-
-# Step 3: Install the necessary dependencies.
-npm i
-
-# Step 4: Start the development server with auto-reloading and an instant preview.
+```bash
+npm install
 npm run dev
 ```
 
-**Edit a file directly in GitHub**
+## Variáveis de ambiente
 
-- Navigate to the desired file(s).
-- Click the "Edit" button (pencil icon) at the top right of the file view.
-- Make your changes and commit the changes.
-
-**Use GitHub Codespaces**
-
-- Navigate to the main page of your repository.
-- Click on the "Code" button (green button) near the top right.
-- Select the "Codespaces" tab.
-- Click on "New codespace" to launch a new Codespace environment.
-- Edit files directly within the Codespace and commit and push your changes once you're done.
-
-## What technologies are used for this project?
-
-This project is built with:
-
-- Vite
-- TypeScript
-- React
-- shadcn-ui
-- Tailwind CSS
-
-## How can I deploy this project?
-
-Simply open [Lovable](https://lovable.dev/projects/ab864f43-07cc-48ce-ba73-fc067a664ad0) and click on Share -> Publish.
-
-## Can I connect a custom domain to my Lovable project?
-
-Yes, you can!
-
-To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
-
-Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+Copie `.env.example` para `.env` e ajuste se necessário.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+COPY . /app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,17 @@
+from pydantic import BaseSettings, Field
+from functools import lru_cache
+
+
+class Settings(BaseSettings):
+    database_url: str = Field(
+        default="sqlite+aiosqlite:///./test.db", env="DATABASE_URL"
+    )
+    secret_key: str = Field(default="secret", env="SECRET_KEY")
+
+    class Config:
+        env_file = ".env"
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,19 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+from .config import get_settings
+
+settings = get_settings()
+
+engine = create_engine(settings.database_url, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+Base = declarative_base()
+
+
+def get_session():
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .db import Base, engine
+from .routers import empresas, demonstrativo, valores
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Trimestral Insight Hub API", version="0.1.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(empresas.router, prefix="/api/v1")
+app.include_router(valores.router, prefix="/api/v1")
+app.include_router(demonstrativo.router, prefix="/api/v1")
+
+
+@app.get("/")
+def read_root():
+    return {"status": "ok"}

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,17 @@
+from .empresa import Empresa
+from .periodo import PeriodoTrimestral
+from .grupo import GrupoConta
+from .conta import Conta
+from .valor import ValorConta
+from .ata import AtaReuniao
+from .participante import ParticipanteReuniao
+
+__all__ = [
+    "Empresa",
+    "PeriodoTrimestral",
+    "GrupoConta",
+    "Conta",
+    "ValorConta",
+    "AtaReuniao",
+    "ParticipanteReuniao",
+]

--- a/backend/app/models/ata.py
+++ b/backend/app/models/ata.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, ForeignKey, Text
+from sqlalchemy.orm import relationship
+
+from .base import Base, TimestampMixin, UUIDBase
+
+
+class AtaReuniao(UUIDBase, TimestampMixin, Base):
+    __tablename__ = "atas"
+
+    empresa_id = Column(ForeignKey("empresas.id"), nullable=False)
+    periodo_id = Column(ForeignKey("periodos.id"), nullable=False)
+    texto = Column(Text, nullable=True)
+
+    participantes = relationship("ParticipanteReuniao", backref="ata")

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -1,0 +1,28 @@
+import uuid
+from sqlalchemy import Column, DateTime, func
+from sqlalchemy.orm import declared_attr
+
+from ..db import Base
+
+try:
+    from sqlalchemy.dialects.postgresql import UUID as PGUUID
+
+    UUIDType = PGUUID
+    UUID_ARGS = {"as_uuid": True}
+except Exception:  # pragma: no cover
+    from sqlalchemy import String as UUIDType  # type: ignore
+
+    UUID_ARGS = {}
+
+
+class TimestampMixin:
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+
+class UUIDBase:
+    @declared_attr
+    def id(cls):  # type: ignore
+        return Column(UUIDType(**UUID_ARGS), primary_key=True, default=uuid.uuid4)

--- a/backend/app/models/conta.py
+++ b/backend/app/models/conta.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from .base import Base, TimestampMixin, UUIDBase
+
+
+class Conta(UUIDBase, TimestampMixin, Base):
+    __tablename__ = "contas"
+
+    codigo = Column(String, unique=True, nullable=False)
+    descricao = Column(String, nullable=False)
+    grupo_id = Column(ForeignKey("grupos.id"), nullable=False)
+    derivada = Column(Boolean, default=False)
+    ordem = Column(Integer, nullable=False)
+
+    grupo = relationship("GrupoConta", backref="contas")

--- a/backend/app/models/empresa.py
+++ b/backend/app/models/empresa.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, String
+
+from .base import Base, TimestampMixin, UUIDBase
+
+
+class Empresa(UUIDBase, TimestampMixin, Base):
+    __tablename__ = "empresas"
+
+    nome = Column(String, nullable=False)
+    cnpj = Column(String, nullable=True)

--- a/backend/app/models/grupo.py
+++ b/backend/app/models/grupo.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String
+
+from .base import Base, TimestampMixin, UUIDBase
+
+
+class GrupoConta(UUIDBase, TimestampMixin, Base):
+    __tablename__ = "grupos"
+
+    nome = Column(String, nullable=False)
+    ordem = Column(Integer, nullable=False)

--- a/backend/app/models/participante.py
+++ b/backend/app/models/participante.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Boolean, Column, ForeignKey, String
+
+from .base import Base, TimestampMixin, UUIDBase
+
+
+class ParticipanteReuniao(UUIDBase, TimestampMixin, Base):
+    __tablename__ = "participantes"
+
+    ata_id = Column(ForeignKey("atas.id"), nullable=False)
+    nome = Column(String, nullable=False)
+    cargo = Column(String, nullable=True)
+    presente = Column(Boolean, default=True)

--- a/backend/app/models/periodo.py
+++ b/backend/app/models/periodo.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, Integer, UniqueConstraint
+
+from .base import Base, TimestampMixin, UUIDBase
+
+
+class PeriodoTrimestral(UUIDBase, TimestampMixin, Base):
+    __tablename__ = "periodos"
+    __table_args__ = (UniqueConstraint("ano", "trimestre"),)
+
+    ano = Column(Integer, nullable=False)
+    trimestre = Column(Integer, nullable=False)

--- a/backend/app/models/valor.py
+++ b/backend/app/models/valor.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, ForeignKey, Numeric, PrimaryKeyConstraint
+
+from .base import Base, TimestampMixin
+
+
+class ValorConta(TimestampMixin, Base):
+    __tablename__ = "valores"
+    __table_args__ = (
+        PrimaryKeyConstraint("empresa_id", "periodo_id", "conta_id"),
+    )
+
+    empresa_id = Column(ForeignKey("empresas.id"), nullable=False)
+    periodo_id = Column(ForeignKey("periodos.id"), nullable=False)
+    conta_id = Column(ForeignKey("contas.id"), nullable=False)
+    valor = Column(Numeric, nullable=False)

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,0 +1,3 @@
+from . import empresas, demonstrativo, valores
+
+__all__ = ["empresas", "demonstrativo", "valores"]

--- a/backend/app/routers/demonstrativo.py
+++ b/backend/app/routers/demonstrativo.py
@@ -1,0 +1,56 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ..db import get_session
+from ..models import Conta, Empresa, PeriodoTrimestral, ValorConta
+from ..schemas.demonstrativo import Demonstrativo, DemonstrativoConta
+from ..services.calculo import calcular_demonstrativo
+
+router = APIRouter(prefix="/empresas", tags=["demonstrativo"])
+
+
+def _parse_periodo(periodo: str):
+    try:
+        ano_str, tri_str = periodo.split("-")
+        ano = int(ano_str)
+        trimestre = int(tri_str.replace("Q", ""))
+        return ano, trimestre
+    except Exception as exc:  # pragma: no cover - simple validation
+        raise HTTPException(status_code=400, detail="periodo inválido") from exc
+
+
+@router.get("/{empresa_id}/demonstrativo", response_model=Demonstrativo)
+def demonstrativo(empresa_id: str, periodo: str, db: Session = Depends(get_session)):
+    ano, trimestre = _parse_periodo(periodo)
+    empresa = db.get(Empresa, empresa_id)
+    if not empresa:
+        raise HTTPException(status_code=404, detail="Empresa não encontrada")
+    periodo_obj = (
+        db.query(PeriodoTrimestral)
+        .filter_by(ano=ano, trimestre=trimestre)
+        .first()
+    )
+    if not periodo_obj:
+        raise HTTPException(status_code=404, detail="Período não encontrado")
+
+    valores = (
+        db.query(ValorConta, Conta)
+        .join(Conta, ValorConta.conta_id == Conta.id)
+        .filter(
+            ValorConta.empresa_id == empresa_id,
+            ValorConta.periodo_id == periodo_obj.id,
+        )
+        .all()
+    )
+    mapa = {conta.codigo: float(vc.valor) for vc, conta in valores}
+    calc = calcular_demonstrativo(mapa)
+
+    contas_resp = [
+        DemonstrativoConta(codigo=k, valor=v) for k, v in mapa.items()
+    ]
+    return Demonstrativo(
+        contas=contas_resp,
+        lucro_liquido=calc["lucro_liquido"],
+        irpj=calc["irpj"] + calc["adicional_ir"],
+        csll=calc["csll"],
+    )

--- a/backend/app/routers/empresas.py
+++ b/backend/app/routers/empresas.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ..db import get_session
+from ..models import Empresa
+from ..schemas.empresa import EmpresaCreate, EmpresaRead
+
+router = APIRouter(prefix="/empresas", tags=["empresas"])
+
+
+@router.post("", response_model=EmpresaRead)
+def create_empresa(data: EmpresaCreate, db: Session = Depends(get_session)):
+    empresa = Empresa(**data.dict())
+    db.add(empresa)
+    db.commit()
+    db.refresh(empresa)
+    return empresa
+
+
+@router.get("", response_model=list[EmpresaRead])
+def list_empresas(db: Session = Depends(get_session)):
+    return db.query(Empresa).all()

--- a/backend/app/routers/valores.py
+++ b/backend/app/routers/valores.py
@@ -1,0 +1,47 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from sqlalchemy import select
+from uuid import uuid4
+
+from ..db import get_session
+from ..models import Conta, PeriodoTrimestral, ValorConta
+from ..schemas.valor import ValorInput
+
+router = APIRouter(prefix="/empresas", tags=["valores"])
+
+
+def _parse_periodo(periodo: str):
+    ano_str, tri_str = periodo.split("-")
+    return int(ano_str), int(tri_str.replace("Q", ""))
+
+
+@router.post("/{empresa_id}/valores")
+def salvar_valores(empresa_id: str, data: ValorInput, db: Session = Depends(get_session)):
+    ano, trimestre = _parse_periodo(data.periodo)
+    periodo = db.query(PeriodoTrimestral).filter_by(ano=ano, trimestre=trimestre).first()
+    if not periodo:
+        periodo = PeriodoTrimestral(ano=ano, trimestre=trimestre)
+        db.add(periodo)
+        db.commit()
+        db.refresh(periodo)
+
+    contas = {c.codigo: c for c in db.execute(select(Conta)).scalars()}
+    for cv in data.valores:
+        conta = contas.get(cv.conta_codigo)
+        if not conta:
+            continue
+        valor = db.query(ValorConta).filter_by(
+            empresa_id=empresa_id, periodo_id=periodo.id, conta_id=conta.id
+        ).first()
+        if not valor:
+            valor = ValorConta(
+                empresa_id=empresa_id,
+                periodo_id=periodo.id,
+                conta_id=conta.id,
+                valor=cv.valor,
+            )
+            db.add(valor)
+        else:
+            valor.valor = cv.valor
+    db.commit()
+    return {"status": "ok"}

--- a/backend/app/schemas/demonstrativo.py
+++ b/backend/app/schemas/demonstrativo.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+
+class DemonstrativoConta(BaseModel):
+    codigo: str
+    valor: float
+
+
+class Demonstrativo(BaseModel):
+    contas: list[DemonstrativoConta]
+    lucro_liquido: float
+    irpj: float
+    csll: float

--- a/backend/app/schemas/empresa.py
+++ b/backend/app/schemas/empresa.py
@@ -1,0 +1,18 @@
+from uuid import UUID
+from pydantic import BaseModel
+
+
+class EmpresaBase(BaseModel):
+    nome: str
+    cnpj: str | None = None
+
+
+class EmpresaCreate(EmpresaBase):
+    pass
+
+
+class EmpresaRead(EmpresaBase):
+    id: UUID
+
+    class Config:
+        orm_mode = True

--- a/backend/app/schemas/valor.py
+++ b/backend/app/schemas/valor.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel
+from uuid import UUID
+
+
+class ContaValor(BaseModel):
+    conta_codigo: str
+    valor: float
+
+
+class ValorInput(BaseModel):
+    periodo: str
+    valores: list[ContaValor]
+
+
+class ValorRead(BaseModel):
+    empresa_id: UUID
+    periodo_id: UUID
+    conta_codigo: str
+    valor: float
+
+    class Config:
+        orm_mode = True

--- a/backend/app/services/calculo.py
+++ b/backend/app/services/calculo.py
@@ -1,0 +1,33 @@
+def calcular_demonstrativo(valores: dict[str, float], prejuizo_acumulado: float = 0.0):
+    receita = valores.get("receitas", 0) - valores.get("deducoes", 0)
+    cmv = valores.get("cmv", 0)
+    lucro_bruto = receita - cmv
+    despesas = valores.get("despesas", 0)
+    lucro_operacional = lucro_bruto - despesas
+    adicoes = valores.get("adicoes", 0)
+    exclusoes = valores.get("exclusoes", 0)
+    base_lalur = lucro_operacional + adicoes - exclusoes
+
+    prejuizo_compensado = min(prejuizo_acumulado, base_lalur * 0.30)
+    base_calculo = base_lalur - prejuizo_compensado
+
+    irpj = base_calculo * 0.15
+    adicional = max(base_calculo - 20000, 0) * 0.10
+    csll = base_calculo * 0.09
+
+    lucro_liquido = lucro_operacional - irpj - adicional - csll
+
+    return {
+        "receita": receita,
+        "cmv": cmv,
+        "lucro_bruto": lucro_bruto,
+        "despesas": despesas,
+        "lucro_operacional": lucro_operacional,
+        "base_lalur": base_lalur,
+        "prejuizo_compensado": prejuizo_compensado,
+        "base_calculo": base_calculo,
+        "irpj": irpj,
+        "adicional_ir": adicional,
+        "csll": csll,
+        "lucro_liquido": lucro_liquido,
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+psycopg2-binary
+pytest

--- a/backend/tests/test_calculo.py
+++ b/backend/tests/test_calculo.py
@@ -1,0 +1,18 @@
+from app.services.calculo import calcular_demonstrativo
+
+
+def test_sem_adicional():
+    valores = {"receitas": 60000, "cmv": 30000, "despesas": 10000}
+    calc = calcular_demonstrativo(valores)
+    assert round(calc["irpj"], 2) == 3000.00
+    assert round(calc["csll"], 2) == 1800.00
+    assert calc["adicional_ir"] == 0
+
+
+def test_com_prejuizo_limite():
+    valores = {"receitas": 100000, "cmv": 40000, "despesas": 10000}
+    calc = calcular_demonstrativo(valores, prejuizo_acumulado=50000)
+    assert round(calc["prejuizo_compensado"], 2) == 15000.00
+    base_calculo = 35000
+    assert round(calc["base_calculo"], 2) == base_calculo
+    assert round(calc["adicional_ir"], 2) == 1500.00

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app
+      POSTGRES_DB: app
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+  backend:
+    build: ./backend
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    volumes:
+      - ./backend:/app
+    environment:
+      DATABASE_URL: postgresql+psycopg2://app:app@db:5432/app
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary
- scaffold FastAPI backend with models for empresas, periodos, contas and valores
- add demonstrativo service applying 30% prejuizo limit and tax calculations
- provide docker-compose, environment example and README instructions

## Testing
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896c0171974832f8f95d795e9faa97d